### PR TITLE
feat: release 3.10.4

### DIFF
--- a/lib/flutter_frontend_server/flutter_frontend_compiler.dart
+++ b/lib/flutter_frontend_server/flutter_frontend_compiler.dart
@@ -56,7 +56,12 @@ class FlutterFrontendCompiler implements frontend.CompilerInterface {
   }
 
   @override
-  Future<Null> recompileDelta({String? entryPoint}) async {
+  Future<bool> setNativeAssets(String nativeAssets) {
+    return _compiler.setNativeAssets(nativeAssets);
+  }
+
+  @override
+  Future<void> recompileDelta({String? entryPoint}) async {
     return _compiler.recompileDelta(entryPoint: entryPoint);
   }
 
@@ -81,7 +86,7 @@ class FlutterFrontendCompiler implements frontend.CompilerInterface {
   }
 
   @override
-  Future<Null> compileExpression(
+  Future<void> compileExpression(
       String expression,
       List<String> definitions,
       List<String> definitionTypes,
@@ -106,7 +111,7 @@ class FlutterFrontendCompiler implements frontend.CompilerInterface {
   }
 
   @override
-  Future<Null> compileExpressionToJs(
+  Future<void> compileExpressionToJs(
       String libraryUri,
       int line,
       int column,


### PR DESCRIPTION
* release 3.10.4
* fix compile error
```shell
❯ dart --deterministic --snapshot=frontend_server.dart.snapshot frontend_server_starter.dart
Info: Compiling with sound null safety.
flutter_frontend_compiler.dart:27:7: Error: The non-abstract class 'FlutterFrontendCompiler' is missing implementations for these members:
 - CompilerInterface.setNativeAssets
Try to either
 - provide an implementation,
 - inherit an implementation from a superclass or mixin,
 - mark the class as abstract, or
 - provide a 'noSuchMethod' implementation.

class FlutterFrontendCompiler implements frontend.CompilerInterface {
      ^^^^^^^^^^^^^^^^^^^^^^^
../../../../dart/sdk/pkg/frontend_server/lib/frontend_server.dart:284:16: Context: 'CompilerInterface.setNativeAssets' is defined here.
  Future<bool> setNativeAssets(String nativeAssets);
               ^^^^^^^^^^^^^^^
flutter_frontend_compiler.dart:60:22: Error: A value of type 'Future<void>' can't be returned from an async function with return type 'Future<Null>'.
 - 'Future' is from 'dart:async'.
    return _compiler.recompileDelta(entryPoint: entryPoint);
                     ^
flutter_frontend_compiler.dart:95:22: Error: A value of type 'Future<void>' can't be returned from a function with return type 'Future<Null>'.
 - 'Future' is from 'dart:async'.
    return _compiler.compileExpression(
                     ^
flutter_frontend_compiler.dart:117:22: Error: A value of type 'Future<void>' can't be returned from a function with return type 'Future<Null>'.
 - 'Future' is from 'dart:async'.
    return _compiler.compileExpressionToJs(libraryUri, line, column, jsModules,

```